### PR TITLE
Filter for tar.gz

### DIFF
--- a/cproton.sh
+++ b/cproton.sh
@@ -141,7 +141,7 @@ InstallationPrompt() {
 
 if [ -z "$parameter" ]; then
   version="$(curl -s $latesturi | grep -E -m1 "tag_name" | cut -d \" -f4)"
-  url=$(curl -s $latesturi | grep -E -m1 "browser_download_url.*Proton" | cut -d \" -f4)
+  url=$(curl -s $latesturi | grep -E -m1 "browser_download_url.*Proton.*tar.gz" | cut -d \" -f4)
   if [ -d "$dstpath"/Proton-"$version" ]; then
     echo "Proton $version is the latest version and is already installed."
   else

--- a/updatePGEfast.sh
+++ b/updatePGEfast.sh
@@ -13,7 +13,7 @@ dstpath="$HOME/.steam/root/compatibilitytools.d"
   else
     echo "Proton $latestversion is the latest version and is not installed yet."
     echo "Installing Proton $latestverion"
-    url=$(curl -s $latesturi | egrep -m1 "browser_download_url.*Proton" | cut -d \" -f4)
+    url=$(curl -s $latesturi | egrep -m1 "browser_download_url.*Proton.*tar.gz" | cut -d \" -f4)
   fi
 
 rsp="$(curl -sI "$url" | head -1)"


### PR DESCRIPTION
Filter for tar.gz file to prevent downloading wrong file type i.E. .sha256sum or else.